### PR TITLE
Bump saintcoinach-py for BC7 icon support

### DIFF
--- a/contrib/ffxiv-upload-achievement-icons/poetry.lock
+++ b/contrib/ffxiv-upload-achievement-icons/poetry.lock
@@ -1227,16 +1227,16 @@ files = []
 develop = false
 
 [package.dependencies]
-Pillow = {version = ">=9.0", optional = true}
+Pillow = {version = ">=9.2", optional = true}
 
 [package.extras]
-images = ["Pillow (>=9.0)"]
+images = ["Pillow (>=9.2)"]
 
 [package.source]
 type = "git"
 url = "https://github.com/aquarion/saintcoinach-py.git"
-reference = "b1a081a323b4949e69d06c47f0b32e0a61d70cc9"
-resolved_reference = "b1a081a323b4949e69d06c47f0b32e0a61d70cc9"
+reference = "f36c994676746d79aa85b58f26949d192c32fedc"
+resolved_reference = "f36c994676746d79aa85b58f26949d192c32fedc"
 
 [[package]]
 name = "tomlkit"
@@ -1413,4 +1413,4 @@ dev = ["pytest", "setuptools"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "e586fc1e1b17937adefb844b39f5cbccb324cf570d2e7c96a8c1c602bb8af356"
+content-hash = "39263e0d78fd6d8a493b69b8a2b2dbcf8f72e7855cd74f2fb8d5520b2e349997"

--- a/contrib/ffxiv-upload-achievement-icons/pyproject.toml
+++ b/contrib/ffxiv-upload-achievement-icons/pyproject.toml
@@ -20,7 +20,7 @@ pre-commit = "^4.5.1"
 # commit so `poetry install` installs it straight from the lock rather than
 # re-checking the remote branch head on every run (bump this rev to pick up
 # saintcoinach-py updates).
-saintcoinach = { git = "https://github.com/aquarion/saintcoinach-py.git", rev = "b1a081a323b4949e69d06c47f0b32e0a61d70cc9", extras = ["images"] }
+saintcoinach = { git = "https://github.com/aquarion/saintcoinach-py.git", rev = "f36c994676746d79aa85b58f26949d192c32fedc", extras = ["images"] }
 
 [tool.poetry.group.dev.dependencies]
 flake8 = "^7.1.2"


### PR DESCRIPTION
## Why

Some achievement icons (e.g. `ui/icon/060000/060031.tex` and its `_hr1`) are stored as **BC7**, which the pinned `saintcoinach-py` revision didn't decode — they failed during export with:

```
Failed to export icon ui/icon/060000/060031.tex: Unsupported image format <ImageFormat.UNKNOWN: 0>
```

(FFXIV re-encoded a range of icons to BC7 in later patches; the original .NET SaintCoinach never handled BC7 either, so this was a genuine gap, not a regression.)

## What

Bumps the `saintcoinach` git dependency from `b1a081a` → [`f36c994`](https://github.com/aquarion/saintcoinach-py/commit/f36c994676746d79aa85b58f26949d192c32fedc), which adds BC7 decoding (via Pillow's native DDS/BCn reader — already our image dependency, so no new packages), and regenerates `poetry.lock`. Only `pyproject.toml` and `poetry.lock` change.

After this, the previously-failing icons export normally.

## Try it

```bash
poetry install   # picks up the new pinned revision
poetry run python update_sc_and_update_icons.py
```

The `ffxiv-icons-tests` check will be red for the same **pre-existing, unrelated** reason as before (the workflow runs `poetry install` at the repo root against the root project's SSH git dep) — not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxrQjAWeawBAM15Q4be83A)_