### PR TITLE
Add advanced CodeQL workflow so inline suppression comments work

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: '23 4 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      packages: read
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: python
+          # Python is interpreted; CodeQL needs no build step, and this
+          # avoids invoking poetry against the monorepo's SSH-only git
+          # dependencies (see .github/workflows/ffxiv-icons-tests.yml).
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:python"


### PR DESCRIPTION
## Summary

- On #130, CodeQL kept re-flagging a false-positive "clear-text logging of sensitive information" alert on the Tumblr OAuth authorize-link print — the same false positive already documented and suppressed in the pre-migration `imports/tumblr.py`/`historic.py` (`# codeql[py/clear-text-logging-sensitive-data]`, added because the OAuth 1.0a request token must appear in a URL for the user to visit and authorize; it's not the secret half of the token pair).
- Moving the suppression comment around didn't help, because this repo has no CodeQL workflow file — it's using GitHub's **Default setup**, which does not honor inline `# codeql[...]` suppression comments at all. Those only take effect under an advanced/custom CodeQL workflow.
- Adds `.github/workflows/codeql.yml` (advanced setup) so inline suppression comments start working. Python needs no build step (`build-mode: none`), so this doesn't need to invoke `poetry install` against the monorepo's SSH-only git dependencies (same constraint noted in `.github/workflows/ffxiv-icons-tests.yml`).

## Action needed after merge

**Default setup must be disabled** in *Settings → Code security → Code scanning* for this workflow to take over — GitHub won't run both simultaneously. I can't toggle that setting via API/git, so this needs to be done manually.

## Test plan

- [x] YAML validated (`yaml.safe_load`)
- [x] `pre-commit run` clean on the new file
- [ ] Confirm the workflow actually runs and inline suppression is honored, once Default setup is disabled (can't verify from this environment)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01JHkDUK2grPFD9Jf2Fv3SWd

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHkDUK2grPFD9Jf2Fv3SWd)_