### PR TITLE
Add pytest and pre-commit GitHub Actions workflows

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,26 @@
+name: Pre-commit
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Set up Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: '3.12'
+
+    - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,42 @@
+name: Pytest
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Set up Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: '3.12'
+
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+
+    - name: Cache Poetry dependencies
+      uses: actions/cache@v6
+      with:
+        path: .venv
+        key: ${{ runner.os }}-lifestream-venv-${{ hashFiles('pyproject.toml') }}
+
+    - name: Install dependencies
+      run: poetry install --no-interaction
+
+    - name: Run tests with pytest
+      run: poetry run pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -35,6 +35,14 @@ jobs:
         path: .venv
         key: ${{ runner.os }}-lifestream-venv-${{ hashFiles('pyproject.toml') }}
 
+    - name: Use system git client for VCS dependencies
+      # Poetry 2.x's default pure-Python git client (dulwich) fails to
+      # negotiate the protocol against GitHub in CI (HangupException /
+      # "remote server unexpectedly closed the connection") when fetching
+      # git dependencies. See python-poetry/poetry#10167 and
+      # .github/workflows/ffxiv-icons-tests.yml.
+      run: poetry config system-git-client true
+
     - name: Install dependencies
       run: poetry install --no-interaction
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ google-auth = "^2.50.0"
 google-auth-httplib2 = "^0.3.1"
 googleapis-common-protos = "^1.74.0"
 #guildwars2api @ https://github.com/aquarion/guildwars2api/archive/refs/tags/0.1a.tar.gz
-guildwars2api = { git = "git@github.com:aquarion/guildwars2api.git", tag = "0.1a" }
+guildwars2api = { git = "https://github.com/aquarion/guildwars2api.git", tag = "0.1a" }
 h11 = "^0.16.0"
 httplib2 = "^0.31.0"
 httpretty = "^1.1.4"


### PR DESCRIPTION
## Summary
- Add `.github/workflows/pytest.yml`: installs the project with Poetry and runs `pytest` on push/PR to `main`.
- Add `.github/workflows/pre-commit.yml`: runs the repo's existing `.pre-commit-config.yaml` hooks (the `pre-commit-hooks` set, black, isort, flake8) on push/PR to `main` via `pre-commit/action`.
- Switch the `guildwars2api` dependency in `pyproject.toml` from an SSH git URL (`git@github.com:...`) to HTTPS, so `poetry install` can resolve it anonymously in CI. This mirrors the constraint already documented in `.github/workflows/ffxiv-icons-tests.yml` and `.github/workflows/codeql.yml`, both of which explicitly avoid running `poetry install` against the root `pyproject.toml` because of this SSH-only dependency — since `aquarion/guildwars2api` is a public repo, HTTPS works without any CI secrets.

## Test plan
- [x] `poetry install --no-interaction` succeeds from a clean checkout (no `poetry.lock` committed; it's gitignored)
- [x] `poetry run pytest` — 142 passed
- [x] `poetry run pre-commit run --all-files` — all hooks pass
- [ ] CI workflows run green on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzegpWEu1xV7NuFDDriumd)_