### PR TITLE
Fix pickle-RCE cache risk and silent-failure bugs in tumblr/lastfm importers

### DIFF
--- a/src/lifestream/__init__.py
+++ b/src/lifestream/__init__.py
@@ -9,7 +9,7 @@ __version__ = "2.0.0"
 
 # Expose core submodules so tests and callers can do `from lifestream import cache`
 from lifestream.core import cache, db, jobs, notifications
-from lifestream.core.cache import file_cache, get_redis_connection
+from lifestream.core.cache import get_redis_connection, redis_cache
 
 # Re-export commonly used items for convenience
 from lifestream.core.config import (
@@ -46,7 +46,7 @@ __all__ = [
     "get_cursor",
     # Cache
     "get_redis_connection",
-    "file_cache",
+    "redis_cache",
     # Utils
     "niceTimeDelta",
     "yearsago",

--- a/src/lifestream/core/__init__.py
+++ b/src/lifestream/core/__init__.py
@@ -11,8 +11,8 @@ This module provides:
 
 from .cache import (
     check_and_set_backoff,
-    file_cache,
     get_redis_connection,
+    redis_cache,
     set_backoff,
     should_backoff,
 )
@@ -66,7 +66,7 @@ __all__ = [
     "set_backoff",
     "should_backoff",
     "check_and_set_backoff",
-    "file_cache",
+    "redis_cache",
     # Utils
     "niceTimeDelta",
     "yearsago",

--- a/src/lifestream/core/cache.py
+++ b/src/lifestream/core/cache.py
@@ -1,9 +1,7 @@
 """Caching functionality for Lifestream."""
 
+import json
 import logging
-import os
-import pickle
-import time
 
 import redis
 
@@ -67,13 +65,13 @@ def check_and_set_backoff(warning_id: str, hours: int = 24) -> int | bool:
         return cxn.ttl(warning_id)
 
 
-def file_cache(cache_id: str, maxage: int):
+def redis_cache(cache_id: str, maxage: int):
     """
-    A decorator that caches function results to a file.
+    A decorator that caches a function's JSON-serializable result in Redis.
 
     Args:
-        cache_id: Identifier for the cache file (stored in /tmp/)
-        maxage: Maximum age of cache in seconds
+        cache_id: Redis key to store the cached result under
+        maxage: Maximum age of the cached result in seconds (Redis TTL)
 
     Returns:
         Decorator function
@@ -81,30 +79,17 @@ def file_cache(cache_id: str, maxage: int):
 
     def decorator(fn):
         def wrapped(*args, **kwargs):
-            cachefile = "/tmp/" + cache_id
-            logger = logging.getLogger("file_cache")
+            cxn = get_redis_connection()
+            logger = logging.getLogger("redis_cache")
 
-            if os.path.exists(cachefile):
-                modified = os.path.getmtime(cachefile)
-                logger.debug(f"Found cache file at '{cachefile}'")
-                now = time.time()
-                if now > (modified + maxage):
-                    logger.debug(f"Ignoring old cache file '{cachefile}'")
-                else:
-                    with open(cachefile, "rb") as cachehandle:
-                        logger.info(f"Using cached result from '{cachefile}'")
-                        try:
-                            return pickle.load(cachehandle)
-                        except (pickle.UnpicklingError, EOFError):
-                            logger.warning(
-                                f"Corrupted cache file '{cachefile}', recomputing"
-                            )
+            cached = cxn.get(cache_id)
+            if cached is not None:
+                logger.info(f"Using cached result for '{cache_id}'")
+                return json.loads(cached)
 
             res = fn(*args, **kwargs)
-
-            with open(cachefile, "wb") as cachehandle:
-                logger.info(f"Saving result to cache '{cachefile}'")
-                pickle.dump(res, cachehandle)
+            logger.info(f"Saving result to cache '{cache_id}'")
+            cxn.set(cache_id, json.dumps(res), ex=maxage)
 
             return res
 

--- a/src/lifestream/core/cache.py
+++ b/src/lifestream/core/cache.py
@@ -84,8 +84,15 @@ def redis_cache(cache_id: str, maxage: int):
 
             cached = cxn.get(cache_id)
             if cached is not None:
-                logger.info(f"Using cached result for '{cache_id}'")
-                return json.loads(cached)
+                try:
+                    result = json.loads(cached)
+                except (json.JSONDecodeError, TypeError, ValueError):
+                    logger.warning(
+                        f"Corrupted cache value for '{cache_id}', recomputing"
+                    )
+                else:
+                    logger.info(f"Using cached result for '{cache_id}'")
+                    return result
 
             res = fn(*args, **kwargs)
             logger.info(f"Saving result to cache '{cache_id}'")

--- a/src/lifestream/importers/gw2.py
+++ b/src/lifestream/importers/gw2.py
@@ -6,11 +6,11 @@ import requests
 from guildwars2api.base import GuildWars2APIError
 from guildwars2api.v2 import GuildWars2API
 
-from lifestream.core import check_and_set_backoff, file_cache, niceTimeDelta
+from lifestream.core import check_and_set_backoff, niceTimeDelta, redis_cache
 from lifestream.importers.base import BaseImporter
 
 
-@file_cache("gw2.categories", 86400)
+@redis_cache("gw2.categories", 86400)
 def _get_categories():
     list_response = requests.get(
         "https://api.guildwars2.com/v2/achievements/categories/", timeout=30

--- a/src/lifestream/importers/lastfm.py
+++ b/src/lifestream/importers/lastfm.py
@@ -39,7 +39,7 @@ class LastfmImporter(FeedImporter):
         fp = feedparser.parse(url)
 
         status = getattr(fp, "status", None)
-        if status is not None and status >= 400:
+        if status is not None and not 200 <= status < 300:
             raise RuntimeError(f"Failed to fetch feed at {url}: HTTP {status}")
 
         if fp.bozo:

--- a/src/lifestream/importers/lastfm.py
+++ b/src/lifestream/importers/lastfm.py
@@ -38,6 +38,21 @@ class LastfmImporter(FeedImporter):
 
         fp = feedparser.parse(url)
 
+        status = getattr(fp, "status", None)
+        if status is not None and status >= 400:
+            raise RuntimeError(f"Failed to fetch feed at {url}: HTTP {status}")
+
+        if fp.bozo:
+            import urllib.error
+
+            if isinstance(fp.bozo_exception, urllib.error.URLError):
+                raise RuntimeError(
+                    f"Failed to fetch feed at {url}: {fp.bozo_exception}"
+                )
+            self.logger.warning(
+                "Feed at %s is not well-formed: %s", url, fp.bozo_exception
+            )
+
         for o_item in fp["entries"]:
 
             item_id = hashlib.md5()

--- a/src/lifestream/importers/tumblr.py
+++ b/src/lifestream/importers/tumblr.py
@@ -134,6 +134,9 @@ class TumblrImporter(OAuthImporter):
 
         while startat < max_posts:
             details = tumblr.posts(blog, offset=startat, limit=20)
+            if "errors" in details:
+                self.logger.error("Error fetching %s: %s", blog, details["meta"]["msg"])
+                return False
             startat += 20
 
             posts = details["posts"]

--- a/src/lifestream/importers/tumblr.py
+++ b/src/lifestream/importers/tumblr.py
@@ -116,13 +116,18 @@ class TumblrImporter(OAuthImporter):
         return title
 
     def process_blog(self, tumblr, blog, full_import):
-        """Import posts from a single Tumblr blog."""
+        """Import posts from a single Tumblr blog.
+
+        Returns:
+            True if the blog was imported successfully, False if fetching
+            it failed.
+        """
         self.logger.info(blog)
 
         details = tumblr.posts(blog)
         if "errors" in details:
             self.logger.error("Error fetching %s: %s", blog, details["meta"]["msg"])
-            return
+            return False
 
         max_posts = details["blog"]["posts"] if full_import else 20
         startat = 0.0
@@ -161,6 +166,8 @@ class TumblrImporter(OAuthImporter):
                     fulldata_json=post,
                 )
 
+        return True
+
     def run(self) -> None:
         """Import posts from all configured Tumblr blogs."""
         full_import = self.args.full_import
@@ -171,8 +178,14 @@ class TumblrImporter(OAuthImporter):
         tumblr = authenticate(self)
         blogs = self.get_config("blogs").split(",")
 
-        for blog in blogs:
-            self.process_blog(tumblr, blog, full_import)
+        failed_blogs = [
+            blog for blog in blogs if not self.process_blog(tumblr, blog, full_import)
+        ]
+
+        if failed_blogs:
+            raise RuntimeError(
+                f"Failed to import Tumblr blog(s): {', '.join(failed_blogs)}"
+            )
 
 
 def main():

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -172,3 +172,19 @@ class TestRedisCache:
         mock_redis.set.assert_called_once_with(
             "test_key", '{"computed": true}', ex=3600
         )
+
+    def test_redis_cache_recomputes_on_corrupted_value(self):
+        """A malformed cached value is recomputed instead of raising or wedging the cache."""
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = "not valid json"
+
+        expensive_function = MagicMock(return_value={"computed": True})
+
+        with patch.object(cache, "get_redis_connection", return_value=mock_redis):
+            result = cache.redis_cache("test_key", maxage=3600)(expensive_function)()
+
+        assert result == {"computed": True}
+        expensive_function.assert_called_once()
+        mock_redis.set.assert_called_once_with(
+            "test_key", '{"computed": true}', ex=3600
+        )

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,8 +1,5 @@
 """Tests for lifestream.core.cache module."""
 
-import os
-import pickle
-import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -143,70 +140,35 @@ class TestBackoff:
             assert result == 7200
 
 
-class TestFileCache:
-    """Tests for file_cache decorator."""
+class TestRedisCache:
+    """Tests for redis_cache decorator."""
 
-    def test_file_cache_returns_cached_result(self):
-        """Test that file_cache returns cached data when fresh."""
-        cache_id = f"test_cache_{time.time()}"
-        cache_path = f"/tmp/{cache_id}"
+    def test_redis_cache_returns_cached_result(self):
+        """Test that redis_cache returns cached data without calling the function."""
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = '{"cached": true}'
 
-        with open(cache_path, "wb") as f:
-            pickle.dump({"cached": True}, f)
+        expensive_function = MagicMock(return_value={"computed": True})
 
-        try:
+        with patch.object(cache, "get_redis_connection", return_value=mock_redis):
+            result = cache.redis_cache("test_key", maxage=3600)(expensive_function)()
 
-            @cache.file_cache(cache_id, maxage=3600)
-            def expensive_function():
-                return {"computed": True}
+        assert result == {"cached": True}
+        expensive_function.assert_not_called()
 
-            result = expensive_function()
-            assert result == {"cached": True}
-        finally:
-            if os.path.exists(cache_path):
-                os.unlink(cache_path)
+    def test_redis_cache_computes_and_stores_on_miss(self):
+        """Test that redis_cache calls the function and stores the JSON result on a miss."""
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = None
 
-    def test_file_cache_computes_when_expired(self):
-        """Test that file_cache recomputes when cache is expired."""
-        cache_id = f"test_expired_{time.time()}"
-        cache_path = f"/tmp/{cache_id}"
+        @cache.redis_cache("test_key", maxage=3600)
+        def expensive_function():
+            return {"computed": True}
 
-        with open(cache_path, "wb") as f:
-            pickle.dump({"cached": True}, f)
-
-        old_time = time.time() - 7200
-        os.utime(cache_path, (old_time, old_time))
-
-        try:
-
-            @cache.file_cache(cache_id, maxage=3600)
-            def expensive_function():
-                return {"computed": True}
-
-            result = expensive_function()
-            assert result == {"computed": True}
-        finally:
-            if os.path.exists(cache_path):
-                os.unlink(cache_path)
-
-    def test_file_cache_creates_new_cache(self):
-        """Test that file_cache creates cache file when none exists."""
-        cache_id = f"test_new_{time.time()}"
-        cache_path = f"/tmp/{cache_id}"
-
-        if os.path.exists(cache_path):
-            os.unlink(cache_path)
-
-        try:
-
-            @cache.file_cache(cache_id, maxage=3600)
-            def expensive_function():
-                return {"computed": True}
-
+        with patch.object(cache, "get_redis_connection", return_value=mock_redis):
             result = expensive_function()
 
-            assert result == {"computed": True}
-            assert os.path.exists(cache_path)
-        finally:
-            if os.path.exists(cache_path):
-                os.unlink(cache_path)
+        assert result == {"computed": True}
+        mock_redis.set.assert_called_once_with(
+            "test_key", '{"computed": true}', ex=3600
+        )

--- a/tests/test_gw2.py
+++ b/tests/test_gw2.py
@@ -1,6 +1,6 @@
 """Tests for Guild Wars 2 achievements importer."""
 
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from guildwars2api.base import GuildWars2APIError
@@ -75,13 +75,17 @@ class TestGW2Importer:
         chunk_response = MagicMock()
         chunk_response.json.return_value = [{"id": 1, "achievements": []}]
 
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = None
+
         with (
             patch(
                 "lifestream.importers.gw2.requests.get",
                 side_effect=[list_response, chunk_response],
             ) as mock_get,
-            patch("lifestream.core.cache.os.path.exists", return_value=False),
-            patch("builtins.open", mock_open()),
+            patch(
+                "lifestream.core.cache.get_redis_connection", return_value=mock_redis
+            ),
         ):
             _get_categories()
 

--- a/tests/test_lastfm.py
+++ b/tests/test_lastfm.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from lifestream.importers.lastfm import LastfmImporter
 
 
@@ -13,6 +15,16 @@ class _FeedEntry(dict):
             return self[name]
         except KeyError:
             raise AttributeError(name)
+
+
+def _make_fp(entries, status=200, bozo=False, bozo_exception=None):
+    """Build a MagicMock standing in for feedparser's top-level FeedParserDict."""
+    fp = MagicMock()
+    fp.status = status
+    fp.bozo = bozo
+    fp.bozo_exception = bozo_exception
+    fp.__getitem__ = lambda _, k: entries if k == "entries" else []
+    return fp
 
 
 class TestLastfmImporter:
@@ -40,7 +52,7 @@ class TestLastfmImporter:
                 link="http://last.fm/2",
             ),
         ]
-        mock_fp_obj = {"entries": entries}
+        mock_fp_obj = _make_fp(entries)
 
         with patch("feedparser.parse", return_value=mock_fp_obj):
             imp.run()
@@ -62,7 +74,7 @@ class TestLastfmImporter:
             updated_parsed=(2024, 1, 1, 12, 0, 0, 0, 1, 0),
             published_parsed=(2024, 1, 1, 12, 0, 0, 0, 1, 0),
         )
-        mock_fp_obj = {"entries": [entry]}
+        mock_fp_obj = _make_fp([entry])
 
         with patch("feedparser.parse", return_value=mock_fp_obj):
             imp.run()
@@ -71,3 +83,50 @@ class TestLastfmImporter:
         fulldata = kwargs["fulldata_json"]
         assert "updated_parsed" not in fulldata
         assert "published_parsed" not in fulldata
+
+    def test_run_raises_on_http_error_status(self):
+        """A non-2xx fetch status raises RuntimeError instead of looking like an empty feed."""
+        imp = self._make_importer()
+        mock_fp_obj = _make_fp([], status=503)
+
+        with patch("feedparser.parse", return_value=mock_fp_obj):
+            with pytest.raises(RuntimeError, match="HTTP 503"):
+                imp.run()
+
+        imp._entry_store.add_entry.assert_not_called()
+
+    def test_run_raises_on_bozo_url_error(self):
+        """A network failure surfaced as a bozo URLError raises RuntimeError."""
+        import urllib.error
+
+        imp = self._make_importer()
+        mock_fp_obj = _make_fp(
+            [],
+            bozo=True,
+            bozo_exception=urllib.error.URLError("connection refused"),
+        )
+
+        with patch("feedparser.parse", return_value=mock_fp_obj):
+            with pytest.raises(RuntimeError, match="Failed to fetch feed"):
+                imp.run()
+
+        imp._entry_store.add_entry.assert_not_called()
+
+    def test_run_warns_on_malformed_but_parseable_feed(self):
+        """A bozo feed with recoverable entries logs a warning but still imports them."""
+        imp = self._make_importer()
+
+        entry = _FeedEntry(
+            guid="1",
+            title="A Song",
+            updated="2024-01-01T12:00:00Z",
+            link="http://last.fm/1",
+        )
+        mock_fp_obj = _make_fp(
+            [entry], bozo=True, bozo_exception=Exception("not well-formed")
+        )
+
+        with patch("feedparser.parse", return_value=mock_fp_obj):
+            imp.run()
+
+        imp._entry_store.add_entry.assert_called_once()

--- a/tests/test_lastfm.py
+++ b/tests/test_lastfm.py
@@ -95,6 +95,17 @@ class TestLastfmImporter:
 
         imp._entry_store.add_entry.assert_not_called()
 
+    def test_run_raises_on_3xx_status(self):
+        """A redirect status feedparser didn't resolve is a failure, not an empty feed."""
+        imp = self._make_importer()
+        mock_fp_obj = _make_fp([], status=304)
+
+        with patch("feedparser.parse", return_value=mock_fp_obj):
+            with pytest.raises(RuntimeError, match="HTTP 304"):
+                imp.run()
+
+        imp._entry_store.add_entry.assert_not_called()
+
     def test_run_raises_on_bozo_url_error(self):
         """A network failure surfaced as a bozo URLError raises RuntimeError."""
         import urllib.error

--- a/tests/test_tumblr.py
+++ b/tests/test_tumblr.py
@@ -127,6 +127,20 @@ class TestTumblrImporter:
         assert args[1] == "123"
         assert args[3] == "tumblr"
 
+    def test_process_blog_stops_on_error_mid_pagination(self):
+        """A paginated fetch returning an error response fails the blog instead of KeyError-ing."""
+        imp = self._make_importer()
+        tumblr = MagicMock()
+        tumblr.posts.side_effect = [
+            {"blog": {"posts": 100}},
+            {"errors": True, "meta": {"msg": "rate limited"}},
+        ]
+
+        result = imp.process_blog(tumblr, "someblog", full_import=True)
+
+        assert result is False
+        imp._entry_store.add_entry.assert_not_called()
+
     def test_run_authenticates_and_processes_each_configured_blog(self):
         imp = self._make_importer()
         imp.get_config = MagicMock(return_value="blog1,blog2")

--- a/tests/test_tumblr.py
+++ b/tests/test_tumblr.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from lifestream.importers.tumblr import TumblrImporter, authenticate
 
 
@@ -95,8 +97,9 @@ class TestTumblrImporter:
         tumblr = MagicMock()
         tumblr.posts.return_value = {"errors": True, "meta": {"msg": "nope"}}
 
-        imp.process_blog(tumblr, "someblog", full_import=False)
+        result = imp.process_blog(tumblr, "someblog", full_import=False)
 
+        assert result is False
         imp._entry_store.add_entry.assert_not_called()
 
     def test_process_blog_adds_entries_for_each_post(self):
@@ -115,8 +118,9 @@ class TestTumblrImporter:
             ],
         }
 
-        imp.process_blog(tumblr, "someblog", full_import=False)
+        result = imp.process_blog(tumblr, "someblog", full_import=False)
 
+        assert result is True
         imp._entry_store.add_entry.assert_called_once()
         args = imp._entry_store.add_entry.call_args.args
         assert args[0] == "text"
@@ -126,7 +130,7 @@ class TestTumblrImporter:
     def test_run_authenticates_and_processes_each_configured_blog(self):
         imp = self._make_importer()
         imp.get_config = MagicMock(return_value="blog1,blog2")
-        imp.process_blog = MagicMock()
+        imp.process_blog = MagicMock(return_value=True)
 
         with patch(
             "lifestream.importers.tumblr.authenticate", return_value="tumblr-client"
@@ -137,3 +141,17 @@ class TestTumblrImporter:
         assert imp.process_blog.call_count == 2
         imp.process_blog.assert_any_call("tumblr-client", "blog1", False)
         imp.process_blog.assert_any_call("tumblr-client", "blog2", False)
+
+    def test_run_raises_when_a_blog_fails_but_still_processes_the_rest(self):
+        """One failing blog is reported, but doesn't stop the others from being tried."""
+        imp = self._make_importer()
+        imp.get_config = MagicMock(return_value="blog1,blog2,blog3")
+        imp.process_blog = MagicMock(side_effect=[True, False, True])
+
+        with patch(
+            "lifestream.importers.tumblr.authenticate", return_value="tumblr-client"
+        ):
+            with pytest.raises(RuntimeError, match="blog2"):
+                imp.run()
+
+        assert imp.process_blog.call_count == 3


### PR DESCRIPTION
## Summary
Fixes the three most pressing open issues from the tracker (one security, two silent-failure bugs), all flagged during review of #146:

- **#147** — `file_cache()` pickled results to a predictable, world-writable-adjacent path in `/tmp` (`/tmp/<cache_id>`), which is a local code-exec risk: any local user could plant a file there and get it unpickled by the next importer run. Redis was already a real, configured dependency in the same file (used for `check_and_set_backoff`), so `file_cache` is replaced with a Redis-backed `redis_cache()` decorator (JSON-serialized, no pickle). `gw2.py`'s `_get_categories()` — its only caller — is converted to use it, and `file_cache` is removed from `core/cache.py` and all re-exports now that nothing in `src/lifestream` calls it. The legacy `imports/lifestream_legacy/cache.py` copy is left untouched, as suggested in the issue, since that package is being phased out importer-by-importer.
- **#148** — `tumblr.py`'s `process_blog()` caught per-blog API errors, logged them, and returned — but `run()` still completed normally, so a failed blog looked identical to a successful job to `jobs.run_import` (no backoff, no failure notification ever fires). `process_blog()` now returns whether it succeeded, and `run()` collects the failed blogs and raises a summary `RuntimeError` at the end, after still attempting every blog.
- **#150** — `lastfm.py` didn't check the feed's `bozo` flag or HTTP status the way `atom.py` does, so a failed fetch (network error, non-2xx, malformed feed) looked identical to a genuinely empty "no new scrobbles" result. Ported the same bozo/HTTP-status handling from `AtomImporter.run()`: raises `RuntimeError` on an unrecoverable bozo exception or non-2xx status, while still importing recoverable/malformed-but-parseable entries.

## Test plan
- [x] `pytest` — 176 passed (all existing tests updated for the new cache/return-value contracts, plus new tests covering the added failure paths)
- [x] `flake8` on all changed files — clean
- [x] `black --check` on all changed files — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01DVmTMwmdp8XGGY6NwzQAxh)_